### PR TITLE
Allow implied countries

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,7 @@ This returns an object of the form:
   international: '+44 (0) 7777 888888',
   local: '07777 888888',
   e164: '447777888888',
+  dialingCode: '44',
+  countryCode: 'GB'
 }
 ```

--- a/src/decorated-number.ts
+++ b/src/decorated-number.ts
@@ -1,4 +1,8 @@
+import dialingCodeToCountryCode from "./data/dialing-code-to-country-code";
 import INumberPart from "./number-part";
+
+const getFilteredPartsText = (parts: INumberPart[], filter: (p: INumberPart) => boolean) =>
+  parts.filter(filter).map((p) => p.text).join("");
 
 export default class DecoratedNumber {
   public parts: INumberPart[];
@@ -8,14 +12,22 @@ export default class DecoratedNumber {
   }
 
   get international() {
-    return this.parts.filter((p) => p.international).map((p) => p.text).join("");
+    return getFilteredPartsText(this.parts, (p) => p.international);
   }
 
   get local() {
-    return this.parts.filter((p) => p.local).map((p) => p.text).join("");
+    return getFilteredPartsText(this.parts, (p) => p.local);
   }
 
   get e164() {
-    return this.parts.filter((p) => p.e164).map((p) => p.text).join("");
+    return getFilteredPartsText(this.parts, (p) => p.e164);
+  }
+
+  get dialingCode() {
+    return getFilteredPartsText(this.parts, (p) => p.dialingCode);
+  }
+
+  get countryCode() {
+    return dialingCodeToCountryCode[this.dialingCode];
   }
 }

--- a/src/decorators/nanp.ts
+++ b/src/decorators/nanp.ts
@@ -15,12 +15,14 @@ const decorator: IDecorator = {
       internationalDecorativePart(" "),
     ]);
 
-    const stripCountryDigit = phoneNumber.substring(1);
+    if (phoneNumber.charAt(0) === "1") {
+      phoneNumber = phoneNumber.substring(1);
+    }
 
-    for (let i = 0; i < stripCountryDigit.length; ++i) {
-      const digit = stripCountryDigit[i];
+    for (let i = 0; i < phoneNumber.length; ++i) {
+      const digit = phoneNumber[i];
 
-      if (i === 0 && stripCountryDigit.length > 2) {
+      if (i === 0 && phoneNumber.length > 2) {
         decoratedNumber.parts.push(decorativePart("("));
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,21 @@
+import ICountry from "./country";
+import countryCodeToDialingCode from "./data/country-code-to-dialing-code";
 import DecoratedNumber from "./decorated-number";
 import decorators from "./decorators/index";
 import detectCountry from "./detect-country";
 
 export default {
-  decorate: (phoneNumber: string): DecoratedNumber => {
-    const country = detectCountry(phoneNumber);
+  decorate: (phoneNumber: string, countryCode?: string): DecoratedNumber => {
+    let country: ICountry | null;
+
+    if (phoneNumber.charAt(0) !== "+" && countryCode && countryCodeToDialingCode[countryCode]) {
+      country = {
+        countryCode,
+        dialingCode: countryCodeToDialingCode[countryCode],
+      };
+    } else {
+      country = detectCountry(phoneNumber);
+    }
 
     if (country === null || decorators[country.countryCode] === null) {
       return new DecoratedNumber([]);

--- a/src/number-part.ts
+++ b/src/number-part.ts
@@ -1,13 +1,15 @@
 export default interface INumberPart {
   decorative: boolean;
+  dialingCode: boolean;
   e164: boolean;
   international: boolean;
   local: boolean;
   text: string;
 }
 
-export const numberPart = (text) => ({
+export const numberPart = (text): INumberPart => ({
   decorative: false,
+  dialingCode: false,
   e164: true,
   international: true,
   local: true,
@@ -16,6 +18,7 @@ export const numberPart = (text) => ({
 
 export const countryCodePart = (text) => ({
   decorative: false,
+  dialingCode: true,
   e164: true,
   international: true,
   local: false,
@@ -24,6 +27,7 @@ export const countryCodePart = (text) => ({
 
 export const decorativePart = (text) => ({
   decorative: true,
+  dialingCode: false,
   e164: false,
   international: true,
   local: true,
@@ -32,6 +36,7 @@ export const decorativePart = (text) => ({
 
 export const localDecorativePart = (text) => ({
   decorative: true,
+  dialingCode: false,
   e164: false,
   international: false,
   local: true,
@@ -40,6 +45,7 @@ export const localDecorativePart = (text) => ({
 
 export const internationalDecorativePart = (text) => ({
   decorative: true,
+  dialingCode: false,
   e164: false,
   international: true,
   local: false,

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,0 +1,29 @@
+import teleformat from "../src";
+
+describe("teleformat", () => {
+  describe("decorate", () => {
+    it("detects countries correctly", () => {
+      expect(teleformat.decorate("447555").dialingCode).toBe("44");
+      expect(teleformat.decorate("447555").countryCode).toBe("GB");
+
+      expect(teleformat.decorate("1999888").dialingCode).toBe("1");
+      expect(teleformat.decorate("1999888").countryCode).toBe("NANP");
+    });
+
+    it("returns correct decorated number with explicit country", () => {
+      expect(teleformat.decorate("5559990000", "NANP").e164).toBe("15559990000");
+      expect(teleformat.decorate("15559990000", "NANP").e164).toBe("15559990000");
+      expect(teleformat.decorate("447555666666", "GB").e164).toBe("447555666666");
+      expect(teleformat.decorate("07555666666", "GB").e164).toBe("447555666666");
+    });
+
+    it("+ overrides explicit country code", () => {
+      expect(teleformat.decorate("+44777666", "NANP").countryCode).toBe("GB");
+    });
+
+    it("returns decorated numbers", () => {
+      expect(teleformat.decorate("61212345678").international).toBe("+61 (02) 1234 5678");
+      expect(teleformat.decorate("61212345678").local).toBe("(02) 1234 5678");
+    });
+  });
+});


### PR DESCRIPTION
Add functionality that allows users to explicitly set a country and have
numbers with no international identifier use that countries dialing code
by default