### PR TITLE
NANP country selection

### DIFF
--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -5,9 +5,33 @@ import nanp from "./nanp";
 import unknown from "./unknown";
 
 const decorators: { [countryCode: string]: IDecorator } = {
+  AG: nanp,
+  AI: nanp,
+  AS: nanp,
   AU: au,
+  BB: nanp,
+  BM: nanp,
+  BS: nanp,
+  CA: nanp,
+  DM: nanp,
+  DO: nanp,
   GB: gb,
+  GD: nanp,
+  GU: nanp,
+  JM: nanp,
+  KN: nanp,
+  KY: nanp,
+  LC: nanp,
+  MS: nanp,
   NANP: nanp,
+  PR: nanp,
+  SX: nanp,
+  TC: nanp,
+  TT: nanp,
+  US: nanp,
+  VC: nanp,
+  VG: nanp,
+  VI: nanp,
   unknown,
 };
 

--- a/src/decorators/nanp.ts
+++ b/src/decorators/nanp.ts
@@ -16,6 +16,14 @@ const decorator: IDecorator = {
       internationalDecorativePart(" "),
     ]);
 
+    // In NANP countries users will often type the local number with a precending 1, in normalizng
+    // the data to be passed through to the decorator we always prepend the country code, this can
+    // result in cases where the user has the country code '1' and the trunk no '1' at the start
+    // of their input. We'll strip it away twice. No local NANP number can start with 1.
+    if (phoneNumber.charAt(0) === "1") {
+      phoneNumber = phoneNumber.substring(1);
+    }
+
     if (phoneNumber.charAt(0) === "1") {
       phoneNumber = phoneNumber.substring(1);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,14 @@ export default {
     let country: ICountry | null;
 
     if (phoneNumber.charAt(0) !== "+" && countryCode && countryCodeToDialingCode[countryCode]) {
+      const dialingCode = countryCodeToDialingCode[countryCode];
+
+      phoneNumber = `${dialingCode}${phoneNumber}`;
       country = {
         countryCode,
-        dialingCode: countryCodeToDialingCode[countryCode],
+        dialingCode,
       };
+
     } else {
       country = detectCountry(phoneNumber);
     }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -10,11 +10,16 @@ describe("teleformat", () => {
       expect(teleformat.decorate("1999888").countryCode).toBe("NANP");
     });
 
-    it("returns correct decorated number with explicit country", () => {
+    it("returns correct e164 with explicit country", () => {
       expect(teleformat.decorate("5559990000", "NANP").e164).toBe("15559990000");
       expect(teleformat.decorate("15559990000", "NANP").e164).toBe("15559990000");
-      expect(teleformat.decorate("447555666666", "GB").e164).toBe("447555666666");
       expect(teleformat.decorate("07555666666", "GB").e164).toBe("447555666666");
+
+      expect(teleformat.decorate("423", "NO").countryCode).toBe("NO");
+      expect(teleformat.decorate("423", "NO").dialingCode).toBe("47");
+      expect(teleformat.decorate("423", "NO").local).toBe("423");
+      expect(teleformat.decorate("423", "NO").international).toBe("+47 423");
+      expect(teleformat.decorate("423", "NO").e164).toBe("47423");
     });
 
     it("+ overrides explicit country code", () => {


### PR DESCRIPTION
Ensure that explicitly selecting a NANP country preserves the country
unless overridden and decorates the number correctly